### PR TITLE
Adds get all instance settings endpoint.

### DIFF
--- a/zestyio-api-wrapper.js
+++ b/zestyio-api-wrapper.js
@@ -16,6 +16,7 @@ class ZestyioAPIWrapper {
       viewsPOST: '/web/views',
       viewsPUT: '/web/views/VIEW_ZUID',
       viewsPUTPUBLISH: '/web/views/VIEW_ZUID?publish=true',
+      settingsGETAll: '/env/settings',
       stylesheetsGETAll: '/web/stylesheets',
       stylesheetsPOST: '/web/stylesheets',
       stylesheetsPUT: '/web/stylesheets/STYLESHEET_ZUID',
@@ -205,6 +206,10 @@ class ZestyioAPIWrapper {
     )
 
     return await this.getRequest(instanceUsersAPIURL)
+  }
+
+  async getSettings() {
+    return await this.getRequest(this.buildAPIURL(this.instancesAPIEndpoints.settingsGETAll))
   }
 
   // Media API functions


### PR DESCRIPTION
Adds ability to get instance settings, needed for the YAML extraction tool.

```
const zesty = new Zesty(
  '<instance zuid>',
  '<token>'
)

const allSettings = await zesty.getSettings()
console.log(JSON.stringify(allSettings.data))
```