### PR TITLE
Adds ability to set title on initial media upload.

### DIFF
--- a/zestyio-api-wrapper.js
+++ b/zestyio-api-wrapper.js
@@ -523,7 +523,7 @@ class ZestyioAPIWrapper {
     return await this.getRequest(mediaBinAPIURL)
   }
 
-  async createMediaFile(binId, groupId, fileName, contentType, stream) {
+  async createMediaFile(binId, groupId, fileName, title, contentType, stream) {
     let bin = await this.getMediaBin(binId)
     bin = bin.data[0]
 
@@ -538,6 +538,7 @@ class ZestyioAPIWrapper {
     return await this.formPostRequest(mediaUploadURL, {
       bin_id: binId,
       group_id: groupId,
+      title: title,
       file: {
         value: stream,
         options: {


### PR DESCRIPTION
This adds the ability to set the "title" attribute for a media file on initial upload.  Previously this would default to the value supplied for the "filename" attribute, and would then have to be changed via a second API call to modify the newly uploaded item.